### PR TITLE
update version v0.16.0

### DIFF
--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaze-style/babel-plugin",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "author": "Taishi Naritomi",
   "description": "Kaze [風] zero-runtime CSS in JS",
@@ -36,6 +36,6 @@
     "@babel/helper-plugin-utils": "^7.20.2"
   },
   "devDependencies": {
-    "@kaze-style/core": "^0.15.0"
+    "@kaze-style/core": "^0.16.0"
   }
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaze-style/build",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "author": "Taishi Naritomi",
   "description": "Kaze [風] zero-runtime CSS in JS",
@@ -31,15 +31,15 @@
     "build": "tsx ./../../scripts/build.ts"
   },
   "dependencies": {
-    "@kaze-style/babel-plugin": "^0.15.0",
-    "@kaze-style/swc-plugin": "^0.15.0",
+    "@kaze-style/babel-plugin": "^0.16.0",
+    "@kaze-style/swc-plugin": "^0.16.0",
     "eval": "^0.1.8",
     "stylis": "^4.1.3"
   },
   "devDependencies": {
-    "@kaze-style/core": "^0.15.0"
+    "@kaze-style/core": "^0.16.0"
   },
   "peerDependencies": {
-    "@kaze-style/core": "^0.15.0"
+    "@kaze-style/core": "^0.16.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaze-style/core",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "author": "Taishi Naritomi",
   "description": "Kaze [風] zero-runtime CSS in JS",

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaze-style/next-plugin",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "author": "Taishi Naritomi",
   "description": "Kaze [風] zero-runtime CSS in JS",
@@ -22,7 +22,7 @@
     "build": "tsx ./../../scripts/build.ts --cjsOnly"
   },
   "dependencies": {
-    "@kaze-style/webpack-plugin": "^0.15.0",
+    "@kaze-style/webpack-plugin": "^0.16.0",
     "browserslist": "^4.21.4"
   },
   "peerDependencies": {

--- a/packages/swc-plugin/package.json
+++ b/packages/swc-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaze-style/swc-plugin",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "author": "Taishi Naritomi",
   "description": "Kaze [風] zero-runtime CSS in JS",
@@ -41,6 +41,6 @@
     "@swc/core": "^1.3.24"
   },
   "devDependencies": {
-    "@kaze-style/core": "^0.15.0"
+    "@kaze-style/core": "^0.16.0"
   }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaze-style/themes",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "author": "Taishi Naritomi",
   "description": "Kaze [風] zero-runtime CSS in JS",
@@ -32,9 +32,9 @@
     "build": "tsx ./../../scripts/build.ts --size"
   },
   "devDependencies": {
-    "@kaze-style/core": "^0.15.0"
+    "@kaze-style/core": "^0.16.0"
   },
   "peerDependencies": {
-    "@kaze-style/core": "^0.15.0"
+    "@kaze-style/core": "^0.16.0"
   }
 }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaze-style/vite-plugin",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "author": "Taishi Naritomi",
   "description": "Kaze [風] zero-runtime CSS in JS",
@@ -31,14 +31,14 @@
     "build": "tsx ./../../scripts/build.ts"
   },
   "dependencies": {
-    "@kaze-style/build": "^0.15.0",
+    "@kaze-style/build": "^0.16.0",
     "esbuild": "^0.16.10"
   },
   "devDependencies": {
-    "@kaze-style/core": "^0.15.0"
+    "@kaze-style/core": "^0.16.0"
   },
   "peerDependencies": {
-    "@kaze-style/core": "^0.15.0",
+    "@kaze-style/core": "^0.16.0",
     "vite": "^3 || ^4"
   }
 }

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaze-style/webpack-plugin",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "author": "Taishi Naritomi",
   "description": "Kaze [風] zero-runtime CSS in JS",
@@ -30,10 +30,10 @@
     "build": "tsx ./../../scripts/build.ts --cjsOnly"
   },
   "dependencies": {
-    "@kaze-style/build": "^0.15.0"
+    "@kaze-style/build": "^0.16.0"
   },
   "peerDependencies": {
-    "@kaze-style/core": "^0.15.0",
+    "@kaze-style/core": "^0.16.0",
     "webpack": "^5"
   }
 }


### PR DESCRIPTION
## Migration

### Change @kaze-style/react -> @kaze-style/core

Deprecated @kaze-style/react to support multiple libraries. You can use @kaze-style/core.

```diff
- yarn add @kaze-style/react or npm i @kaze-style/react
+ yarn add @kaze-style/core or npm i @kaze-style/core
```

```diff
- import { createStyle, crateGlobalStyle, mergeStyle } from '@kaze-style/react';
+ import { createStyle, crateGlobalStyle, mergeStyle } from '@kaze-style/core';
```
```ts
// *.style.ts
// import { createStyle } from '@kaze-style/react';
import { createStyle } from '@kaze-style/core';

export const classes = createStyle({
  base: {
    display: 'flex',
    gap: '5px',
  },
});
```

### Generate Atomic CSS

Atomic CSS is now generated by adding $ prefix.
For styles that do not merge, not atomic has higher performance.

```ts
import { createStyle, mergeStyle } from '@kaze-style/core';

export const classes = createStyle({
  // Not Atomic CSS
  base: {
    display: 'flex',
    gap: '5px',
  },
  //  Atomic CSS (add $ prefix)
  $base: {
    display: 'flex',
    gap: '5px',
  },
  $baseAction: {
    display: 'block',
  },
});

// Not Work
mergeStyle(classes.base, classes.$baseAction)

// Work
mergeStyle(classes.$base, classes.$baseAction)
```

## PR
[Fix support RSC #96](https://github.com/taishinaritomi/kaze-style/pull/96)
[Next solution #98](https://github.com/taishinaritomi/kaze-style/pull/98)
[Fix docs #99](https://github.com/taishinaritomi/kaze-style/pull/99)
[Fix core type #100](https://github.com/taishinaritomi/kaze-style/pull/100)
