### PR TITLE
POC: Limited AST for preTransforms in TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 target
 .swc
 benchmark
+.idea

--- a/packages/babel-plugin/src/transformPlugin.ts
+++ b/packages/babel-plugin/src/transformPlugin.ts
@@ -52,6 +52,8 @@ export const transformPlugin = declare<
     visitor: {
       Program: {
         exit(path, state) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           const _styles = styles.map(([classes, index]) => ({
             classes,
             index,

--- a/packages/core/src/__preStyle.ts
+++ b/packages/core/src/__preStyle.ts
@@ -2,6 +2,74 @@ import { resolveStyle } from './resolveStyle';
 import type { Classes, ForBuild } from './types/common';
 import type { KazeStyle } from './types/style';
 
+enum SerializedKind {
+  String = 0,
+  Null = 1,
+  Number = 2,
+  Boolean = 3,
+  Array = 4,
+  ObjectExpression = 5,
+  ObjectProperty = 6,
+  Custom = 7,
+}
+
+export type SerializedValues = SerializedString | SerializedObjectProperty | SerializedObject | SerializedCustom;
+
+interface SerializedObject {
+  kind: SerializedKind.ObjectExpression;
+  value: SerializedObjectProperty[];
+}
+
+interface SerializedString {
+  kind: SerializedKind.String;
+  value: string;
+}
+
+interface SerializedObjectProperty {
+  kind: SerializedKind.ObjectProperty;
+  key: string;
+  value: SerializedValues;
+}
+
+interface SerializedCustom {
+  kind: SerializedKind.Custom
+  constructor: string;
+  value: SerializedValues;
+}
+
+// Todo: this is temporary, we would create better utility functions for serializing.
+//  but the idea is that people can hook into the transpilation process from typescript.
+function serialise(input: Record<string, unknown>): SerializedObject {
+  const result: SerializedObjectProperty[] = [];
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === 'string') {
+      result.push({
+        kind: SerializedKind.ObjectProperty,
+        key,
+        value: {
+          kind: SerializedKind.String,
+          value,
+        },
+      });
+    } else if (typeof value === 'object') {
+      const nestedValue = serialise(value as Record<string, unknown>);
+      result.push({
+        kind: SerializedKind.ObjectProperty,
+        key,
+        value: {
+          kind: SerializedKind.Custom,
+          constructor: 'ClassName',
+          value: nestedValue,
+        },
+      });
+    }
+  }
+  return {
+    kind: SerializedKind.ObjectExpression,
+    value: result,
+  };
+}
+
 export const __preStyle = <K extends string>(
   styles: KazeStyle<K>,
   forBuild: ForBuild<K>,
@@ -11,7 +79,11 @@ export const __preStyle = <K extends string>(
   const [cssRules, classes, staticClasses] = resolveStyle(styles);
   if (forBuild[0] === filename) {
     forBuild[1].push(...cssRules);
-    forBuild[2].push([staticClasses, index]);
+    // forBuild[2].push([staticClasses, index]);
+    forBuild[2].push({
+      index,
+      arguments: [serialise(staticClasses)],
+    })
   }
 
   return classes;

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -25,8 +25,15 @@ export type ClassOverride<T, K extends string = '$class'> = ClassNameOverride<
 
 export type Selectors = [selector: string, atRules: string[], groups: string];
 
+type Temp = {
+  index: number;
+  arguments: any[];
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 export type ForBuild<T extends string = string> = [
   filename: string,
   cssRules: CssRule[],
-  styles: [classes: StaticClasses<T>, index: number][],
+  styles: Temp[],
 ];

--- a/packages/swc-plugin/Cargo.lock
+++ b/packages/swc-plugin/Cargo.lock
@@ -160,6 +160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,8 +494,10 @@ dependencies = [
 name = "kaze-style-transform-swc-plugin"
 version = "0.1.0"
 dependencies = [
+ "fxhash",
  "serde",
  "serde_json",
+ "serde_repr",
  "swc_core",
 ]
 
@@ -1127,6 +1144,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/swc-plugin/package.json
+++ b/packages/swc-plugin/package.json
@@ -34,7 +34,7 @@
     "code-check": "cargo fmt --check",
     "type-check": "tsc --noEmit",
     "exports-check": "publint",
-    "dev": "tsx ./../../scripts/build --watch --exec='cargo watch -x \"build-wasi --release --quiet\"'",
+    "dev": "tsx ./../../scripts/build --watch",
     "build": "tsx ./../../scripts/build --exec='cargo build-wasi --release --quiet'"
   },
   "dependencies": {

--- a/packages/swc-plugin/plugins/transform/Cargo.toml
+++ b/packages/swc-plugin/plugins/transform/Cargo.toml
@@ -9,4 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = "1"
 serde_json = "1.0.89"
+serde_repr = "0.1"
+fxhash = "0.2.1"
 swc_core = { version = "0.44.*", features = ["plugin_transform"] }

--- a/packages/swc-plugin/plugins/transform/src/config.rs
+++ b/packages/swc-plugin/plugins/transform/src/config.rs
@@ -1,0 +1,267 @@
+use serde::{Deserialize, Serialize};
+use serde_repr::*;
+use swc_core::common::DUMMY_SP;
+use swc_core::ecma::ast::{Expr, ExprOrSpread, Ident, KeyValueProp, Lit, NewExpr, ObjectLit, Prop, PropName, PropOrSpread, Str};
+
+#[derive(Debug, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+enum SerializedKind {
+  String = 0,
+  // Todo
+  Null = 1,
+  // Todo
+  Number = 2,
+  // Todo
+  Boolean = 3,
+  Array = 4,
+  ObjectExpression = 5,
+  ObjectProperty = 6,
+  Custom = 7,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SerializedValues {
+  SerializedString(SerializedString),
+  SerializedObjectProperty(SerializedObjectProperty),
+  SerializedObject(SerializedObject),
+  SerializedCustom(SerializedCustom),
+  SerializedArray(SerializedArray),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SerializedArray {
+  kind: SerializedKind,
+  value: Vec<SerializedValues>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SerializedObject {
+  kind: SerializedKind,
+  value: Box<Vec<SerializedObjectProperty>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SerializedObjectProperty {
+  kind: SerializedKind,
+  key: String,
+  value: Box<SerializedValues>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SerializedString {
+  kind: SerializedKind,
+  value: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SerializedCustom {
+  kind: SerializedKind,
+  constructor: String,
+  value: Box<SerializedValues>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportSpecifier {
+  pub specifier: String,
+  pub source: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InputStyle {
+  index: f64,
+  arguments: Vec<SerializedValues>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InputConfig {
+  transforms: Vec<Transform>,
+  imports: Vec<ImportSpecifier>,
+  styles: Vec<InputStyle>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Transform {
+  pub from: ImportSpecifier,
+  pub to: ImportSpecifier,
+}
+
+#[derive(Debug)]
+pub struct Style {
+  pub index: f64,
+  pub arguments: Vec<Expr>,
+}
+
+#[derive(Debug)]
+pub struct Config {
+  pub transforms: Vec<Transform>,
+  pub imports: Vec<ImportSpecifier>,
+  pub styles: Vec<Style>,
+}
+
+// Todo: it's possible that we can use actual json AST to do this - we'll have to investigate SWC more
+pub fn value_to_expr(value: &SerializedValues) -> Expr {
+  match value {
+    SerializedValues::SerializedString(string) => {
+      Expr::Lit(Lit::Str(Str {
+        value: string.value.clone().into(),
+        span: DUMMY_SP,
+        raw: None,
+      }))
+    }
+    SerializedValues::SerializedObject(object) => {
+      let mut properties = vec![];
+
+      for x in object.value.iter() {
+        let key = PropName::Ident(Ident::new(x.key.clone().into(), DUMMY_SP));
+        let value = value_to_expr(&x.value);
+
+        let prop = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+          key,
+          value: Box::new(value),
+        })));
+
+        properties.push(prop);
+      }
+
+      Expr::Object(ObjectLit {
+        span: DUMMY_SP,
+        props: properties,
+      })
+    }
+    SerializedValues::SerializedCustom(custom) => {
+      // todo: we should check for to see if we have safe identifier
+      let constructor = Ident::new(custom.constructor.clone().into(), DUMMY_SP);
+      let value = value_to_expr(&custom.value);
+
+      Expr::New(NewExpr {
+        span: DUMMY_SP,
+        callee: Box::new(Expr::Ident(constructor)),
+        args: Some(vec![ExprOrSpread {
+          spread: None,
+          expr: Box::new(value),
+        }]),
+        type_args: None,
+      })
+    }
+    _ => unimplemented!(),
+  }
+}
+
+pub fn json_to_config(json: Option<String>) -> Config {
+  let config: Result<InputConfig, serde_json::Error> = if let Some(config) = json {
+    serde_json::from_str(&config)
+  } else {
+    panic!("config parse Error")
+  };
+
+  let config = match config {
+    Ok(config) => config,
+    Err(_) => panic!("config parse Error"),
+  };
+
+  let styles = config.styles
+    .iter()
+    .map(|style| {
+      Style {
+        index: style.index,
+        arguments: style.arguments
+          .iter()
+          .map(|argument| value_to_expr(argument))
+          .collect::<Vec<Expr>>()
+      }
+    }).collect::<Vec<Style>>();
+
+  Config {
+    transforms: config.transforms,
+    imports: config.imports,
+    styles,
+  }
+}
+
+#[test]
+fn serde2() {
+  let config = r#"
+    {
+      "transforms": [{
+        "from": {
+          "specifier": "__preStyle",
+          "source": "@kaze-style/core"
+        },
+        "to": {
+          "specifier": "__style",
+          "source": "@kaze-style/core"
+        }
+      }],
+      "imports": [{
+        "specifier": "ClassName",
+        "source": "@kaze-style/core"
+      }],
+      "styles": [{
+        "index": 0,
+        "arguments": [{
+          "kind": 5,
+          "value": [{
+              "kind": 6,
+              "key": "container",
+              "value": {
+                "kind": 0,
+                "value": "_11s457t"
+              }
+            },
+            {
+              "kind": 6,
+              "key": "$button",
+              "value": {
+                "kind": 7,
+                "constructor": "ClassName",
+                "value": {
+                  "kind": 5,
+                  "value": [{
+                    "kind": 6,
+                    "key": "_xy62pb",
+                    "value": {
+                      "kind": 0,
+                      "value": "_1ioqvwq"
+                    }
+                  }]
+                }
+              }
+            },
+            {
+              "kind": 6,
+              "key": "$blueButton",
+              "value": {
+                "kind": 7,
+                "constructor": "ClassName",
+                "value": {
+                  "kind": 5,
+                  "value": [{
+                      "kind": 6,
+                      "key": "_t7zwuo",
+                      "value": {
+                        "kind": 0,
+                        "value": "_1q6qasc"
+                      }
+                    },
+                    {
+                      "kind": 6,
+                      "key": "_5rb1nc",
+                      "value": {
+                        "kind": 0,
+                        "value": "_qq53s5"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }]
+      }]
+    }
+  "#;
+
+  let config = json_to_config(Some(config.into()));
+  println!("{:#?}", config);
+}


### PR DESCRIPTION
Okay!

DO NOT MERGE.

With regards to my comment [here](https://github.com/taishinaritomi/kaze-style/issues/118#issuecomment-1431478381), I've created this POC. 

It took a bit longer time than I expected, since I wasn't very familiar with Rust or how to write SWC plugins before this.

A few things to note:

1. It's only the swc/transform plugin that has been updated - I haven't touched babel yet.
2. I've left a bunch of comments all over the place - these would of course be cleaned up.
3. I haven't put any thought into where I've placed the TypeScript definitions. I just wanted to get it to work.
4. I've only tested it with `playground/next`.
5. It feels like the "forBuild"-idea is solid, but objects can have references as well, so we can probably simplify it if this idea is viable.
6. The default options (`packages/swc-plugin/src/transform.ts#L43`) could be specified in the swc/babel plugin as defaults.
 
It's very rough, and messy at the moment. But due to the time difference from Sweden to Japan, I wanted to get it out there before you go to sleep.

The idea is that library authors might want to extend the functionality of the engine. This would allow for that.

I imagine an api like this:

```typescript
function myPlugin() {
  return {
    transforms: [{
      from: {
        specifier: '__preCreateTheme',
        source: 'my-theming-library'
      },
      to: {
        specifier: '__createTheme',
        source: 'my-theming-library'
      }
    },
  };
}

const withKazeStyle = createKazeStylePlugin({
  swc: true, cssLayer: true, plugins: [
    myPlugin(),
  ]
});
```

Then my `__preCreateTheme` would create a serialisation that matches what needs to be done. 

Again, super early draft of my idea. I haven't had much time to work on it in code. But I think it's pretty flushed out conceptually. 

Please take a look @taishinaritomi :)

*Edit:*
I also think that with this concept, we could remove the `preTransform `-plugins from babel and swc and adapt the new one I've written, to do all the work for us. Maybe. Just a thought!