### PR TITLE
fix github actions rust version

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -29,6 +29,8 @@ jobs:
             ~/.cargo/git/db/
             packages/swc-plugin/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('packages/swc-plugin/Cargo.lock') }}
+      - name: setup rust version
+        run: rustup override set 1.64.0 && rustup component add rustfmt
       - name: install wasm target
         run: rustup target add wasm32-wasi
       - name: install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: setup rust version
+        run: rustup override set 1.64.0 && rustup component add rustfmt
       - name: install wasm target
         run: rustup target add wasm32-wasi
       - name: install


### PR DESCRIPTION
Wasm build crashes in rust 1.7.x.
Change github actions rust from 1.7.x to 1.6.x